### PR TITLE
Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ MANIFEST
 *.so
 **.ipynb_checkpoints/
 test/new_dvs.es
+.vagrant

--- a/README.md
+++ b/README.md
@@ -38,5 +38,14 @@ loris.write_events_to_file(event_array, "/path/to/my-file.es", ordering)
 loris.write_events_to_file(structured_event_array, "/path/to/my-file.es")
 ~~~
 
+### Windows test (for developers)
+
+To make sure the library works on Windows (if you use macOS or Linux), follow these steps:
+
+1. Download Vagrant (https://www.vagrantup.com/)
+2. `cd windows`
+3. `vagrant up` (this will download a virtual machine and build the package)
+4. `vargrant ssh` (optional, to inspect the Windows VM)
+5. `vagrant destroy -f` (cleanup)
 
 ![loris](loris.gif "The Loris Banner")

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
+import setuptools
 import distutils.command.build
 import distutils.core
 import os
 import re
-import setuptools
 import shutil
 import subprocess
 import sys
@@ -12,7 +12,7 @@ def check_submodules():
     """ verify that the submodules are checked out and clean
         use `git submodule update --init --recursive`; on failure
     """
-    if not os.path.exists('.git'):
+    if os.environ.get('LORIS_SKIP_GIT', None) is not None or not os.path.exists('.git'):
         return
     with open('.gitmodules') as f:
         for l in f:
@@ -79,6 +79,15 @@ with open('README.md', 'r') as file:
     long_description = file.read()
 
 # setup the package
+if sys.platform == 'darwin':
+    extra_args = ['-std=c++11','-stdlib=libc++']
+    libraries = []
+elif sys.platform == 'win32':
+    extra_args = []
+    libraries = []
+else:
+    extra_args = ['-std=c++11']
+    libraries = ['pthread']
 setuptools.setup(
     name='loris',
     version='0.5.1',
@@ -100,10 +109,10 @@ setuptools.setup(
         'loris_extension',
         language='c++',
         sources=[os.path.join(dirname, 'loris', 'loris_extension.cpp')],
-        extra_compile_args=(['-std=c++11'] if sys.platform == 'linux' else ['-std=c++11','-stdlib=libc++']),
-        extra_link_args=(['-std=c++11'] if sys.platform == 'linux' else ['-std=c++11','-stdlib=libc++']),
+        extra_compile_args=extra_args,
+        extra_link_args=extra_args,
         include_dirs=[],
-        libraries=(['pthread'] if sys.platform == 'linux' else [])
+        libraries=libraries
     )],
     cmdclass={'build_ext': build_ext_factory, "sdist": sdist_checked}
 )

--- a/windows/Vagrantfile
+++ b/windows/Vagrantfile
@@ -1,0 +1,30 @@
+$install = <<-'SCRIPT'
+function Install-Python($version, $suffix) {
+    Write-Output "installing python $version$suffix"
+    Invoke-WebRequest `
+        -URI "https://www.python.org/ftp/python/$version/python-$version$suffix.exe" `
+        -OutFile "C:\Users\vagrant\python-$version$suffix.exe" `
+        -UseBasicParsing
+    & "C:\Users\vagrant\python-$version$suffix.exe" /quiet `
+        InstallAllUsers=1 `
+        PrependPath=1 `
+        Include_test=0
+}
+Install-Python 3.9.2 ''
+choco install microsoft-visual-cpp-build-tools -y
+Set-ItemProperty HKCU:\Environment Path `
+    "$([System.Environment]::GetEnvironmentVariable("Path", "Machine"));$([System.Environment]::GetEnvironmentVariable("Path", "User"))"
+SCRIPT
+
+$build = <<-'SCRIPT'
+cd C:\io
+$env:LORIS_SKIP_GIT = 'true'
+C:\Program` Files` `(x86`)\Python39-32\python.exe setup.py build
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "gusztavvargadr/windows-10"
+  config.vm.synced_folder "../", "C:\\io"
+  config.vm.provision "shell", inline: $install
+  config.vm.provision "shell", inline: $build, run: "always"
+end


### PR DESCRIPTION
Fixes #8 

The issue comes from an MSVC bug related to packing + full template specialization. I pushed a fix to Sepia and updated command_line_tools (a dependency of Loris) accordingly.

This PR also adds a Windows VM configuration file to Loris. It can be used to test Windows builds. We could also use it to generate and push binaries to PyPI (see for example https://github.com/neuromorphicsystems/aedat#publish).